### PR TITLE
feat: implement primary session management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ DerivedDataCache
 test_results/
 
 Sources/WalletConnectModal/Secrets/secrets.json
+
+# Claude configuration
+Claude.MD

--- a/Sources/ReownAppKit/Core/AppKit.swift
+++ b/Sources/ReownAppKit/Core/AppKit.swift
@@ -19,6 +19,12 @@ import UIKit
 /// AppKit.instance.getSessions()
 /// ```
 public class AppKit {
+    /// Primary session topic for wallet connection
+    public static var primarySessionTopic: String? {
+        get { UserDefaults.standard.string(forKey: "appkit.primarySessionTopic") }
+        set { UserDefaults.standard.set(newValue, forKey: "appkit.primarySessionTopic") }
+    }
+    
     /// AppKit client instance
     public static var instance: AppKitClient = {
         guard let config = AppKit.config else {
@@ -34,7 +40,12 @@ public class AppKit {
         
         let store = Store.shared
         
-        if let session = client.getSessions().first {
+        // Try to find primary session first, then fall back to first session
+        let session = primarySessionTopic != nil 
+            ? client.getSessions().first(where: { $0.topic == primarySessionTopic })
+            : client.getSessions().first
+        
+        if let session = session {
             store.session = session
             store.connectedWith = .wc
             store.account = .init(from: session)

--- a/Sources/ReownAppKit/Core/AppKitClient.swift
+++ b/Sources/ReownAppKit/Core/AppKitClient.swift
@@ -267,9 +267,21 @@ public class AppKitClient {
     }
 
     /// Query sessions
-    /// - Returns: All sessions
+    /// - Returns: All sessions with primary session first
     public func getSessions() -> [Session] {
-        signClient.getSessions()
+        let allSessions = signClient.getSessions()
+        
+        // Sort sessions with primary session first
+        guard let primaryTopic = AppKit.primarySessionTopic else {
+            return allSessions
+        }
+        
+        return allSessions.sorted { lhs, rhs in
+            if lhs.topic == primaryTopic { return true }
+            if rhs.topic == primaryTopic { return false }
+            // Secondary sort by timestamp to maintain consistent order
+            return lhs.expiryDate < rhs.expiryDate
+        }
     }
     
     /// Query pairings

--- a/Sources/ReownAppKit/Sheets/Web3ModalViewModel.swift
+++ b/Sources/ReownAppKit/Sheets/Web3ModalViewModel.swift
@@ -153,6 +153,9 @@ class Web3ModalViewModel: ObservableObject {
         store.connectedWith = .wc
         store.account = .init(from: session)
         store.session = session
+        
+        // Set this session as the primary session
+        AppKit.primarySessionTopic = session.topic
 
         if
             let blockchain = session.accounts.first?.blockchain,

--- a/Sources/ReownAppKit/Store.swift
+++ b/Sources/ReownAppKit/Store.swift
@@ -38,6 +38,14 @@ class Store: ObservableObject {
     }
     
     // WalletConnect specific
+    var walletSession: Session? {
+        // Try to find primary session first, then fall back to first session
+        if let primaryTopic = AppKit.primarySessionTopic {
+            return AppKit.instance.getSessions().first(where: { $0.topic == primaryTopic })
+        }
+        return AppKit.instance.getSessions().first
+    }
+    
     @Published var session: Session? {
         didSet {
             if let blockchain = session?.accounts.first?.blockchain {


### PR DESCRIPTION
- Add primarySessionTopic property to AppKit for persistent primary session tracking
- Modify getSessions() to always return primary session first
- Add walletSession computed property to Store for consistent primary session access
- Set primary session topic when new wallet connection is established
- Ensure consistent session ordering across app restarts

This fixes the issue where dApp connections could appear before the main wallet connection in getSessions() results.
