### PR TITLE
feat: add updatePrimarySession method to programmatically set active …

### DIFF
--- a/Sources/ReownAppKit/Core/AppKit.swift
+++ b/Sources/ReownAppKit/Core/AppKit.swift
@@ -81,6 +81,24 @@ public class AppKit {
 
     private init() {}
 
+    /// Updates the primary session by re-initializing the store with the specified session
+    /// - Parameter topic: The session topic to set as primary. If nil or if the session doesn't exist, the method returns without changes.
+    /// - Note: This method allows apps to programmatically select which session should be the active one,
+    ///         useful for apps that manage multiple wallet connections and need to ensure a specific session
+    ///         is treated as the primary wallet connection regardless of session ordering.
+    public static func updatePrimarySession(_ topic: String?) {
+        guard let topic = topic else { return }
+        
+        // Find the session with the specified topic
+        guard let session = instance.getSessions().first(where: { $0.topic == topic }) else { return }
+        
+        // Re-initialize the store with this session
+        let store = Store.shared
+        store.session = session
+        store.connectedWith = .wc
+        store.account = .init(from: session)
+    }
+
     /// Wallet instance wallet config method.
     /// - Parameters:
     ///   - metadata: App metadata


### PR DESCRIPTION
## Changelog

### Added
- `updatePrimarySession(_ topic: String?)` method to programmatically set the active session in AppKit

### What's New

#### Primary Session Management
- **New Method**: `AppKit.updatePrimarySession(_ topic: String?)` allows apps to explicitly set which session should be treated as the active/primary connection
- **Store Re-initialization**: The method finds the session with the specified topic and re-initializes the AppKit store with that session
- **Graceful Handling**: Returns silently if the topic is nil or if no matching session exists

### Why This Change?

This feature addresses an issue for apps that manage multiple WalletConnect sessions:

- **Problem**: When apps have multiple sessions (main wallet + dApp connections), the initializing logic for AppKit uses the first one as default.
- **Solution**: Apps can now explicitly set their main wallet session as primary, ensuring consistent behavior regardless of session creation order

### Usage Example

```swift
// During app initialization, after AppKit.configure()
if let storedWalletTopic = getMainWalletSessionTopic() {
    AppKit.updatePrimarySession(storedWalletTopic)
}

// When reconnecting to a specific wallet
AppKit.updatePrimarySession(selectedWallet.sessionTopic)