### PR TITLE
feat: add primary session persistence to prevent overwriting

### DIFF
--- a/Sources/ReownAppKit/Core/AppKit.swift
+++ b/Sources/ReownAppKit/Core/AppKit.swift
@@ -19,6 +19,12 @@ import UIKit
 /// AppKit.instance.getSessions()
 /// ```
 public class AppKit {
+    /// Primary session topic to maintain the main wallet connection
+    private static var primarySessionTopic: String? {
+        get { UserDefaults.standard.string(forKey: "appkit.primarySessionTopic") }
+        set { UserDefaults.standard.set(newValue, forKey: "appkit.primarySessionTopic") }
+    }
+
     /// AppKit client instance
     public static var instance: AppKitClient = {
         guard let config = AppKit.config else {
@@ -34,7 +40,12 @@ public class AppKit {
         
         let store = Store.shared
         
-        if let session = client.getSessions().first {
+        // Try to find primary session first, then fall back to first session
+        let session = primarySessionTopic != nil
+            ? client.getSessions().first(where: { $0.topic == primarySessionTopic })
+            : client.getSessions().first
+
+        if let session = session {
             store.session = session
             store.connectedWith = .wc
             store.account = .init(from: session)
@@ -81,6 +92,11 @@ public class AppKit {
 
     private init() {}
 
+    /// Checks if a primary session has been set
+    internal static var hasPrimarySession: Bool {
+        return primarySessionTopic != nil
+    }
+
     /// Updates the primary session by re-initializing the store with the specified session
     /// - Parameter topic: The session topic to set as primary. If nil or if the session doesn't exist, the method returns without changes.
     /// - Note: This method allows apps to programmatically select which session should be the active one,
@@ -92,7 +108,8 @@ public class AppKit {
         // Find the session with the specified topic
         guard let session = instance.getSessions().first(where: { $0.topic == topic }) else { return }
         
-        // Re-initialize the store with this session
+        // Set as primary session and re-initialize the store
+        primarySessionTopic = topic
         let store = Store.shared
         store.session = session
         store.connectedWith = .wc

--- a/Sources/ReownAppKit/Sheets/Web3ModalViewModel.swift
+++ b/Sources/ReownAppKit/Sheets/Web3ModalViewModel.swift
@@ -150,19 +150,22 @@ class Web3ModalViewModel: ObservableObject {
     }
 
     private func handleNewSession(session: Session) {
-        store.connectedWith = .wc
-        store.account = .init(from: session)
-        store.session = session
+        // Only update the store session if we don't have a primary session set
+        // This prevents dApp connections from overwriting the main wallet session
+        if !AppKit.hasPrimarySession {
+            store.connectedWith = .wc
+            store.account = .init(from: session)
+            store.session = session
 
-        if
-            let blockchain = session.accounts.first?.blockchain,
-            let matchingChain = ChainPresets.ethChains.first(where: { $0.chainNamespace == blockchain.namespace && $0.chainReference == blockchain.reference })
-        {
-            store.selectedChain = matchingChain
+            if
+                let blockchain = session.accounts.first?.blockchain,
+                let matchingChain = ChainPresets.ethChains.first(where: { $0.chainNamespace == blockchain.namespace && $0.chainReference == blockchain.reference })
+            {
+                store.selectedChain = matchingChain
+            }
+
+            fetchIdentity()
         }
-
-        fetchIdentity()
-
     }
 
     private func routeToProfile() {


### PR DESCRIPTION
- Add primarySessionTopic property to persist the main wallet session
- Update initialization to respect primarySessionTopic when available
- Prevent handleNewSession from overwriting primary session once set
- Add hasPrimarySession property for internal session state checks

This ensures that once a primary wallet session is set via updatePrimarySession, subsequent dApp connections won't overwrite it.